### PR TITLE
Add support for zstd compression format.

### DIFF
--- a/archive-rpm.el
+++ b/archive-rpm.el
@@ -148,6 +148,15 @@ assumed to be empty."
                          "xz" t t nil "-q" "-c" "-d")))
         (unless (zerop exit-code)
           (error "xz decompression failed: %s" (buffer-string)))))
+     ((equal "zstd" payload-compressor)
+      (insert payload)
+      (let* ((coding-system-for-write 'no-conversion)
+             (coding-system-for-read 'no-conversion)
+             (exit-code (call-process-region
+                         (point-min) (point-max)
+                         "zstd" t t nil "-q" "-c" "-d")))
+        (unless (zerop exit-code)
+          (error "zstd decompression failed: %s" (buffer-string)))))
      (t
       (error "Unknown RPM payload compressor `%s'" payload-compressor)))))
 


### PR DESCRIPTION
Newer versions of RPM use zstd for compression. This PR adds support for it. For testing you can use e.g. this small RPM https://ftp.fau.de/mageia/distrib/cauldron/x86_64/media/nonfree/release/alsa-sof-firmware-debug-1.9.2-1.mga9.nonfree.noarch.rpm (which I choose by chance just because it is small).